### PR TITLE
Update to d-Lev librarian to exclude device specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ d-lib
 d-a32
 d-arm
 d-lib.cfg
+_WORK_/
+*.eeprom


### PR DESCRIPTION
This PR updates the .gitIgnore file to exclude the WORK folder and also the .eeprom files.

These files are specific to a single D-Lev device and should probably not be in the repo.